### PR TITLE
Fix: GH_TOKEN for workflow push

### DIFF
--- a/.github/workflows/P00-meta-workflow.yml
+++ b/.github/workflows/P00-meta-workflow.yml
@@ -409,7 +409,8 @@ jobs:
           git commit -m "meta-workflow: PR #${PR_NUMBER} ${ROUND_ID}" || echo "nothing to commit"
           git pull --rebase origin "$(git rev-parse --abbrev-ref HEAD)" || echo "pull rebase skipped"
           git push "https://x-access-token:${PAT_TOKEN}@github.com/${{ github.repository }}" HEAD
-          # workflow 檔案用 gh api 推送（git push 對 GitHub App token 會拒絕 workflow 檔案）
+          # workflow 檔案用 gh api + PAT_TOKEN 推送（GITHUB_TOKEN App token 無法 push workflow 檔案）
+          export GH_TOKEN="$PAT_TOKEN"
           for wf in .github/workflows/P*.yml; do
             [[ -f "$wf" ]] || continue
             content=$(base64 -w0 "$wf")


### PR DESCRIPTION
Set GH_TOKEN=PAT_TOKEN so gh api uses PAT for workflow file push