### PR TITLE
Fix: support PR review comments

### DIFF
--- a/.github/workflows/P00-meta-workflow.yml
+++ b/.github/workflows/P00-meta-workflow.yml
@@ -41,10 +41,14 @@ jobs:
             echo "FAIL: token check (HTTP $http_code)"
             echo "skip=true" >> "$GITHUB_OUTPUT"; exit 0
           fi
-          # last comment check: 抓 PR 最後一則 comment author，若是 bot = user 還沒追問
-          last_author=$(gh pr view "$pr_number" --json comments -q '.comments[-1].author.login // empty')
+          # last message check: 合併 comments + reviews，取最後一則非 bot 的 author
+          last_author=$(gh pr view "$pr_number" --json comments,reviews -q '
+            ([.comments[]? | {author: .author.login, time: .createdAt}] +
+             [.reviews[]? | select(.state == "COMMENTED") | {author: .author.login, time: .submittedAt}])
+            | sort_by(.time) | last.author // empty
+          ')
           if [[ -n "$last_author" ]] && [[ "$last_author" == *"bot"* || "$last_author" == "github-actions"* || "$last_author" == "app/"* || "$last_author" == *"[bot]"* ]]; then
-            echo "FAIL: last comment is bot ($last_author)"
+            echo "FAIL: last message is bot ($last_author)"
             echo "skip=true" >> "$GITHUB_OUTPUT"; exit 0
           fi
           # label check: PR 必須帶有 project:P00-meta-workflow label
@@ -96,7 +100,7 @@ jobs:
             git checkout "$pr_branch"
           fi
           mkdir -p memory/log output
-          gh pr view "$PR_NUMBER" --json body,comments > /tmp/pr_data.json
+          gh pr view "$PR_NUMBER" --json body,comments,reviews > /tmp/pr_data.json
           python3 "$CHATLOG" /tmp/chatlog.json load-context-from-pr-log < /tmp/pr_data.json > /tmp/load_output.txt 2>&1
           cat /tmp/load_output.txt
           round_line=$(grep -oE 'current round R[0-9]+' /tmp/load_output.txt | grep -oE 'R[0-9]+')

--- a/.github/workflows/P00-meta-workflow/scripts/chatlog.py
+++ b/.github/workflows/P00-meta-workflow/scripts/chatlog.py
@@ -25,18 +25,22 @@ chatlog.py — 維護對話陣列的工具，支援基本陣列指令。
   chatlog.py <json-file> clear                             清空
   chatlog.py <json-file> rounds                            列出所有 round
 
-load-context-from-pr-log 的 stdin 格式（gh pr view --json body,comments 原始輸出）：
+load-context-from-pr-log 的 stdin 格式（gh pr view --json body,comments,reviews 原始輸出）：
 {
   "body": "PR body 原文",
   "comments": [
     {"author": {"login": "..."}, "body": "<!-- chatlog:summary:R1 -->...", "createdAt": "..."},
     {"author": {"login": "FATESAIKOU"}, "body": "user comment", "createdAt": "..."},
     ...
+  ],
+  "reviews": [
+    {"author": {"login": "FATESAIKOU"}, "body": "NG\n請修正", "state": "COMMENTED", "submittedAt": "..."},
+    ...
   ]
 }
 
 bot comment 透過 body 內的 <!-- chatlog:summary:R1 --> HTML comment tag 標記為 summary。
-chatlog.py 會：過濾 bot comments、用 tag 識別 summary、按 createdAt 排序 user comments、
+chatlog.py 會：過濾 bot comments/reviews、用 tag 識別 summary、按 createdAt/submittedAt 排序 user 訊息、
 配對 user/assistant 交替、current round 只加 user 不加 assistant。
 """
 import json
@@ -163,7 +167,7 @@ def main() -> int:
         # 與 user comments（非 bot author），按 createdAt 排序
         comments = gh_data.get("comments", [])
         summaries: dict[str, str] = {}
-        user_comments: list[dict] = []
+        user_messages: list[dict] = []
         for c in comments:
             login = c.get("author", {}).get("login", "")
             cbody = c.get("body", "")
@@ -172,9 +176,20 @@ def main() -> int:
             if tag_type == "summary" and tag_round:
                 summaries[tag_round] = strip_tag(cbody)
             elif not is_bot(login):
-                user_comments.append({"body": cbody, "createdAt": created})
-        user_comments.sort(key=lambda c: c["createdAt"])
-        user_texts = [c["body"] for c in user_comments]
+                user_messages.append({"body": cbody, "createdAt": created})
+
+        # 也從 reviews 抓 user 訊息（PR review comment，非一般 comment）
+        reviews = gh_data.get("reviews", [])
+        for r in reviews:
+            login = r.get("author", {}).get("login", "")
+            rbody = r.get("body", "")
+            submitted = r.get("submittedAt", "")
+            state = r.get("state", "")
+            if not is_bot(login) and rbody.strip() and state == "COMMENTED":
+                user_messages.append({"body": rbody, "createdAt": submitted})
+
+        user_messages.sort(key=lambda c: c["createdAt"])
+        user_texts = [c["body"] for c in user_messages]
 
         # round id = PR body 算第 1 次 + user comments 數
         current_num = 1 + len(user_texts)

--- a/.github/workflows/P01-general-tech.yml
+++ b/.github/workflows/P01-general-tech.yml
@@ -50,10 +50,14 @@ jobs:
             echo "skip=true" >> "$GITHUB_OUTPUT"; exit 0
           fi
 
-          # last comment check: 抓 PR 最後一則 comment author，若是 bot = user 還沒追問
-          last_author=$(gh pr view "$pr_number" --json comments -q '.comments[-1].author.login // empty')
+          # last message check: 合併 comments + reviews，取最後一則非 bot 的 author
+          last_author=$(gh pr view "$pr_number" --json comments,reviews -q '
+            ([.comments[]? | {author: .author.login, time: .createdAt}] +
+             [.reviews[]? | select(.state == "COMMENTED") | {author: .author.login, time: .submittedAt}])
+            | sort_by(.time) | last.author // empty
+          ')
           if [[ -n "$last_author" ]] && [[ "$last_author" == *"bot"* || "$last_author" == "github-actions"* || "$last_author" == "app/"* || "$last_author" == *"[bot]"* ]]; then
-            echo "FAIL: last comment is bot ($last_author)"
+            echo "FAIL: last message is bot ($last_author)"
             echo "skip=true" >> "$GITHUB_OUTPUT"; exit 0
           fi
 
@@ -109,7 +113,7 @@ jobs:
             git checkout "$pr_branch"
           fi
           mkdir -p memory/log output
-          gh pr view "$PR_NUMBER" --json body,comments > /tmp/pr_data.json
+          gh pr view "$PR_NUMBER" --json body,comments,reviews > /tmp/pr_data.json
           python3 "$CHATLOG" /tmp/chatlog.json load-context-from-pr-log < /tmp/pr_data.json > /tmp/load_output.txt 2>&1
           cat /tmp/load_output.txt
           round_line=$(grep -oE 'current round R[0-9]+' /tmp/load_output.txt | grep -oE 'R[0-9]+')

--- a/.github/workflows/P01-general-tech/scripts/chatlog.py
+++ b/.github/workflows/P01-general-tech/scripts/chatlog.py
@@ -25,18 +25,22 @@ chatlog.py — 維護對話陣列的工具，支援基本陣列指令。
   chatlog.py <json-file> clear                             清空
   chatlog.py <json-file> rounds                            列出所有 round
 
-load-context-from-pr-log 的 stdin 格式（gh pr view --json body,comments 原始輸出）：
+load-context-from-pr-log 的 stdin 格式（gh pr view --json body,comments,reviews 原始輸出）：
 {
   "body": "PR body 原文",
   "comments": [
     {"author": {"login": "..."}, "body": "<!-- chatlog:summary:R1 -->...", "createdAt": "..."},
     {"author": {"login": "FATESAIKOU"}, "body": "user comment", "createdAt": "..."},
     ...
+  ],
+  "reviews": [
+    {"author": {"login": "FATESAIKOU"}, "body": "NG\n請修正", "state": "COMMENTED", "submittedAt": "..."},
+    ...
   ]
 }
 
 bot comment 透過 body 內的 <!-- chatlog:summary:R1 --> HTML comment tag 標記為 summary。
-chatlog.py 會：過濾 bot comments、用 tag 識別 summary、按 createdAt 排序 user comments、
+chatlog.py 會：過濾 bot comments/reviews、用 tag 識別 summary、按 createdAt/submittedAt 排序 user 訊息、
 配對 user/assistant 交替、current round 只加 user 不加 assistant。
 """
 import json
@@ -163,7 +167,7 @@ def main() -> int:
         # 與 user comments（非 bot author），按 createdAt 排序
         comments = gh_data.get("comments", [])
         summaries: dict[str, str] = {}
-        user_comments: list[dict] = []
+        user_messages: list[dict] = []
         for c in comments:
             login = c.get("author", {}).get("login", "")
             cbody = c.get("body", "")
@@ -172,9 +176,20 @@ def main() -> int:
             if tag_type == "summary" and tag_round:
                 summaries[tag_round] = strip_tag(cbody)
             elif not is_bot(login):
-                user_comments.append({"body": cbody, "createdAt": created})
-        user_comments.sort(key=lambda c: c["createdAt"])
-        user_texts = [c["body"] for c in user_comments]
+                user_messages.append({"body": cbody, "createdAt": created})
+
+        # 也從 reviews 抓 user 訊息（PR review comment，非一般 comment）
+        reviews = gh_data.get("reviews", [])
+        for r in reviews:
+            login = r.get("author", {}).get("login", "")
+            rbody = r.get("body", "")
+            submitted = r.get("submittedAt", "")
+            state = r.get("state", "")
+            if not is_bot(login) and rbody.strip() and state == "COMMENTED":
+                user_messages.append({"body": rbody, "createdAt": submitted})
+
+        user_messages.sort(key=lambda c: c["createdAt"])
+        user_texts = [c["body"] for c in user_messages]
 
         # round id = PR body 算第 1 次 + user comments 數
         current_num = 1 + len(user_texts)

--- a/.github/workflows/W00-watch.yml
+++ b/.github/workflows/W00-watch.yml
@@ -93,8 +93,8 @@ jobs:
             [[ "$login" == *"bot"* || "$login" == "github-actions"* || "$login" == "app/"* || "$login" == *"[bot]"* ]]
           }
 
-          # 取所有 open PR
-          prs=$(gh pr list --repo "$GH_REPO" --state open --json number,labels,comments --limit 50)
+          # 取所有 open PR（含 reviews）
+          prs=$(gh pr list --repo "$GH_REPO" --state open --json number,labels,comments,reviews --limit 50)
 
           echo "$prs" | jq -c '.[]' | while read -r pr; do
             pr_number=$(echo "$pr" | jq -r .number)
@@ -105,10 +105,15 @@ jobs:
               continue
             fi
 
-            # 判定：最後一則 comment author 是 bot → user 還沒追問，跳過
-            last_author=$(echo "$pr" | jq -r '.comments[-1].author.login // empty')
+            # 判定：最後一則 comment/review author 是 bot → user 還沒追問，跳過
+            # 合併 comments + reviews 按時間排序，取最後一則非 bot 的
+            last_author=$(echo "$pr" | jq -r '
+              ([.comments[]? | {author: .author.login, time: .createdAt}] +
+               [.reviews[]? | select(.state == "COMMENTED") | {author: .author.login, time: .submittedAt}])
+              | sort_by(.time) | last.author // empty
+            ')
             if [[ -n "$last_author" ]] && is_bot "$last_author"; then
-              echo "PR #$pr_number: last comment is bot, skip"
+              echo "PR #$pr_number: last message is bot, skip"
               continue
             fi
 


### PR DESCRIPTION
chatlog.py load-context-from-pr-log now reads reviews. W00-watch + guard steps merge comments+reviews for last-message check.