### PR TITLE
feat: 導入 search-from-mybrain + 權限最小化 token 重構

### DIFF
--- a/.github/workflows/P00-meta-workflow.yml
+++ b/.github/workflows/P00-meta-workflow.yml
@@ -94,14 +94,13 @@ jobs:
       - name: Setup MyBrain search
         working-directory: .
         env:
-          PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+          MYBRAIN_TOKEN: ${{ secrets.MYBRAIN_TOKEN }}
         run: |
           set -euo pipefail
           mkdir -p ~/.config/opencode/skills ~/.config/opencode/commands
           cp -r .agents/skills/search-from-mybrain ~/.config/opencode/skills/
           cp .agents/commands/search-from-mybrain.md ~/.config/opencode/commands/
-          echo "$PAT_TOKEN" | gh auth login --with-token 2>/dev/null || true
-          MYBRAIN_DIR=/tmp/mybrain bash .agents/skills/search-from-mybrain/refresh.sh || true
+          GH_TOKEN="$MYBRAIN_TOKEN" MYBRAIN_DIR=/tmp/mybrain bash .agents/skills/search-from-mybrain/refresh.sh || true
           echo "MyBrain @ $(git -C /tmp/mybrain log -1 --format='%h %ad' --date=short 2>/dev/null || echo 'unavailable')"
 
       - name: Switch to PR branch + build context + round id + paths

--- a/.github/workflows/P00-meta-workflow.yml
+++ b/.github/workflows/P00-meta-workflow.yml
@@ -422,16 +422,16 @@ jobs:
       - name: Commit & push
         working-directory: .
         env:
-          PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+          LEARNGHAGENT_TOKEN: ${{ secrets.LEARNGHAGENT_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add projects/
           git commit -m "meta-workflow: PR #${PR_NUMBER} ${ROUND_ID}" || echo "nothing to commit"
           git pull --rebase origin "$(git rev-parse --abbrev-ref HEAD)" || echo "pull rebase skipped"
-          git push "https://x-access-token:${PAT_TOKEN}@github.com/${{ github.repository }}" HEAD
-          # workflow 檔案用 gh api + PAT_TOKEN 推送（GITHUB_TOKEN App token 無法 push workflow 檔案）
-          export GH_TOKEN="$PAT_TOKEN"
+          git push "https://x-access-token:${LEARNGHAGENT_TOKEN}@github.com/${{ github.repository }}" HEAD
+          # workflow 檔案用 gh api + LEARNGHAGENT_TOKEN 推送（GITHUB_TOKEN App token 無法 push workflow 檔案）
+          export GH_TOKEN="$LEARNGHAGENT_TOKEN"
           for wf in .github/workflows/P*.yml; do
             [[ -f "$wf" ]] || continue
             content=$(base64 -w0 "$wf")

--- a/.github/workflows/P01-general-tech.yml
+++ b/.github/workflows/P01-general-tech.yml
@@ -107,14 +107,13 @@ jobs:
       - name: Setup MyBrain search
         working-directory: .
         env:
-          PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+          MYBRAIN_TOKEN: ${{ secrets.MYBRAIN_TOKEN }}
         run: |
           set -euo pipefail
           mkdir -p ~/.config/opencode/skills ~/.config/opencode/commands
           cp -r .agents/skills/search-from-mybrain ~/.config/opencode/skills/
           cp .agents/commands/search-from-mybrain.md ~/.config/opencode/commands/
-          echo "$PAT_TOKEN" | gh auth login --with-token 2>/dev/null || true
-          MYBRAIN_DIR=/tmp/mybrain bash .agents/skills/search-from-mybrain/refresh.sh || true
+          GH_TOKEN="$MYBRAIN_TOKEN" MYBRAIN_DIR=/tmp/mybrain bash .agents/skills/search-from-mybrain/refresh.sh || true
           echo "MyBrain @ $(git -C /tmp/mybrain log -1 --format='%h %ad' --date=short 2>/dev/null || echo 'unavailable')"
 
       - name: Switch to PR branch + build context + round id + paths

--- a/.github/workflows/P02-code-quality-check.yml
+++ b/.github/workflows/P02-code-quality-check.yml
@@ -103,14 +103,13 @@ jobs:
       - name: Setup MyBrain search
         working-directory: .
         env:
-          PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+          MYBRAIN_TOKEN: ${{ secrets.MYBRAIN_TOKEN }}
         run: |
           set -euo pipefail
           mkdir -p ~/.config/opencode/skills ~/.config/opencode/commands
           cp -r .agents/skills/search-from-mybrain ~/.config/opencode/skills/
           cp .agents/commands/search-from-mybrain.md ~/.config/opencode/commands/
-          echo "$PAT_TOKEN" | gh auth login --with-token 2>/dev/null || true
-          MYBRAIN_DIR=/tmp/mybrain bash .agents/skills/search-from-mybrain/refresh.sh || true
+          GH_TOKEN="$MYBRAIN_TOKEN" MYBRAIN_DIR=/tmp/mybrain bash .agents/skills/search-from-mybrain/refresh.sh || true
           echo "MyBrain @ $(git -C /tmp/mybrain log -1 --format='%h %ad' --date=short 2>/dev/null || echo 'unavailable')"
 
       - name: Switch to PR branch + build context + round id + paths

--- a/.github/workflows/W00-watch.yml
+++ b/.github/workflows/W00-watch.yml
@@ -20,7 +20,7 @@ jobs:
       actions: write
     env:
       GH_REPO: ${{ github.repository }}
-      GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+      GH_TOKEN: ${{ secrets.LEARNGHAGENT_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## 變更

### search-from-mybrain 整合
- 新增 `.agents/skills/search-from-mybrain/` (SKILL.md + refresh.sh)
- 新增 `.agents/commands/search-from-mybrain.md`
- P00/P01/P02 的 `我.md` 改為參照 /search-from-mybrain，移除硬編碼身份資訊
- P00/P01/P02 workflow 加入 MyBrain 鏡像 setup step

### Token 重構
- 刪除舊 classic token（mybrain-reporead, fgw）
- `mybrain-token`（fine-grained）：All repos Contents Read，供 MyBrain + LearnGhAgent clone 用
- `learnghagent-token`（fine-grained）：LearnGhAgent only，Contents/PR/Actions/Workflows RW
- W00-watch `GH_TOKEN` 改用 `LEARNGHAGENT_TOKEN`
- P00 push workflow step 改用 `LEARNGHAGENT_TOKEN`
- MyBrain clone 改用 `GH_TOKEN=\"\\"` 直接傳遞（不用 auth login）

## 測試需求
- MyBrain clone 能否正確運作（需等 CI 跑完確認）