### PR TITLE
fix: MYBRAIN_TOKEN 加入 job env，opencode 內可 fetch MyBrain 更新

### DIFF
--- a/.github/workflows/P00-meta-workflow.yml
+++ b/.github/workflows/P00-meta-workflow.yml
@@ -69,6 +69,7 @@ jobs:
     env:
       GH_REPO: ${{ github.repository }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      MYBRAIN_TOKEN: ${{ secrets.MYBRAIN_TOKEN }}
       OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
       OPENCODE_MODEL: ollama-cloud/${{ vars.OLLAMA_DEFAULT_MODEL || 'deepseek-v4-flash' }}
       OPENCODE_PERMISSION: '{"*":"allow"}'

--- a/.github/workflows/P00-meta-workflow.yml
+++ b/.github/workflows/P00-meta-workflow.yml
@@ -95,8 +95,6 @@ jobs:
 
       - name: Setup MyBrain search
         working-directory: .
-        env:
-          MYBRAIN_TOKEN: ${{ secrets.MYBRAIN_TOKEN }}
         run: |
           set -euo pipefail
           mkdir -p ~/.config/opencode/skills ~/.config/opencode/commands

--- a/.github/workflows/P00-meta-workflow.yml
+++ b/.github/workflows/P00-meta-workflow.yml
@@ -172,7 +172,7 @@ jobs:
             attempt=$((attempt+1))
             echo "::group::Step 1 - 執行 opencode (attempt $attempt/$MAX_RETRY)"
             rm -f "${STEP1_LOG}" "${STEP1_REVIEW}"
-            opencode run --model "$OPENCODE_MODEL" --title "step1-$attempt" "$(cat /tmp/step1_prompt.txt)" || echo "opencode run failed (will validate)"
+            GH_TOKEN="$MYBRAIN_TOKEN" opencode run --model "$OPENCODE_MODEL" --title "step1-$attempt" "$(cat /tmp/step1_prompt.txt)" || echo "opencode run failed (will validate)"
             echo "::endgroup::"
             echo "::group::Step 1 - Hard validate"
             ./judge/validate-step1.sh "${STEP1_LOG}"
@@ -183,7 +183,7 @@ jobs:
               continue
             fi
             echo "::group::Step 1 - Soft validate (opencode review)"
-            opencode run --model "$OPENCODE_MODEL" --title "step1-review-$attempt" "$(cat /tmp/step1_review_prompt.txt)" || echo "review run failed"
+            GH_TOKEN="$MYBRAIN_TOKEN" opencode run --model "$OPENCODE_MODEL" --title "step1-review-$attempt" "$(cat /tmp/step1_review_prompt.txt)" || echo "review run failed"
             echo "::endgroup::"
             if ! grep -q "VERDICT: PASS" "${STEP1_REVIEW}" 2>/dev/null; then
               echo "soft validate FAIL, retry"
@@ -245,7 +245,7 @@ jobs:
             attempt=$((attempt+1))
             echo "::group::Step 2 - 執行 opencode (attempt $attempt/$MAX_RETRY)"
             rm -f "${STEP2_LOG}" "${STEP2_REVIEW}"
-            opencode run --model "$OPENCODE_MODEL" --title "step2-$attempt" "$(cat /tmp/step2_prompt.txt)" || echo "opencode run failed (will validate)"
+            GH_TOKEN="$MYBRAIN_TOKEN" opencode run --model "$OPENCODE_MODEL" --title "step2-$attempt" "$(cat /tmp/step2_prompt.txt)" || echo "opencode run failed (will validate)"
             echo "::endgroup::"
             echo "::group::Step 2 - Hard validate"
             ./judge/validate-step2.sh "${STEP2_LOG}"
@@ -256,7 +256,7 @@ jobs:
               continue
             fi
             echo "::group::Step 2 - Soft validate (opencode review)"
-            opencode run --model "$OPENCODE_MODEL" --title "step2-review-$attempt" "$(cat /tmp/step2_review_prompt.txt)" || echo "review run failed"
+            GH_TOKEN="$MYBRAIN_TOKEN" opencode run --model "$OPENCODE_MODEL" --title "step2-review-$attempt" "$(cat /tmp/step2_review_prompt.txt)" || echo "review run failed"
             echo "::endgroup::"
             if ! grep -q "VERDICT: PASS" "${STEP2_REVIEW}" 2>/dev/null; then
               echo "soft validate FAIL, retry"
@@ -321,7 +321,7 @@ jobs:
             attempt=$((attempt+1))
             echo "::group::Step 3 - 執行 opencode (attempt $attempt/$MAX_RETRY)"
             rm -f "${STEP3_LOG}" "${STEP3_REVIEW}"
-            opencode run --model "$OPENCODE_MODEL" --title "step3-$attempt" "$(cat /tmp/step3_main_prompt.txt)" || echo "opencode run failed (will validate)"
+            GH_TOKEN="$MYBRAIN_TOKEN" opencode run --model "$OPENCODE_MODEL" --title "step3-$attempt" "$(cat /tmp/step3_main_prompt.txt)" || echo "opencode run failed (will validate)"
             echo "::endgroup::"
             echo "::group::Step 3 - Hard validate (step log)"
             ./judge/validate-step3.sh "${STEP3_LOG}"
@@ -332,7 +332,7 @@ jobs:
               continue
             fi
             echo "::group::Step 3 - Soft validate (opencode review)"
-            opencode run --model "$OPENCODE_MODEL" --title "step3-review-$attempt" "$(cat /tmp/step3_review_prompt.txt)" || echo "review run failed"
+            GH_TOKEN="$MYBRAIN_TOKEN" opencode run --model "$OPENCODE_MODEL" --title "step3-review-$attempt" "$(cat /tmp/step3_review_prompt.txt)" || echo "review run failed"
             echo "::endgroup::"
             if ! grep -q "VERDICT: PASS" "${STEP3_REVIEW}" 2>/dev/null; then
               echo "soft validate FAIL, retry"
@@ -395,7 +395,7 @@ jobs:
             attempt=$((attempt+1))
             echo "::group::Step 4 - 執行 opencode (attempt $attempt/$MAX_RETRY)"
             rm -f "${STEP4_LOG}" "${STEP4_REVIEW}"
-            opencode run --model "$OPENCODE_MODEL" --title "step4-$attempt" "$(cat /tmp/step4_prompt.txt)" || echo "opencode run failed (will validate)"
+            GH_TOKEN="$MYBRAIN_TOKEN" opencode run --model "$OPENCODE_MODEL" --title "step4-$attempt" "$(cat /tmp/step4_prompt.txt)" || echo "opencode run failed (will validate)"
             echo "::endgroup::"
             echo "::group::Step 4 - Hard validate"
             ./judge/validate-step4.sh "${STEP4_LOG}"
@@ -406,7 +406,7 @@ jobs:
               continue
             fi
             echo "::group::Step 4 - Soft validate (opencode review)"
-            opencode run --model "$OPENCODE_MODEL" --title "step4-review-$attempt" "$(cat /tmp/step4_review_prompt.txt)" || echo "review run failed"
+            GH_TOKEN="$MYBRAIN_TOKEN" opencode run --model "$OPENCODE_MODEL" --title "step4-review-$attempt" "$(cat /tmp/step4_review_prompt.txt)" || echo "review run failed"
             echo "::endgroup::"
             if ! grep -q "VERDICT: PASS" "${STEP4_REVIEW}" 2>/dev/null; then
               echo "soft validate FAIL, retry"

--- a/.github/workflows/P01-general-tech.yml
+++ b/.github/workflows/P01-general-tech.yml
@@ -108,8 +108,6 @@ jobs:
 
       - name: Setup MyBrain search
         working-directory: .
-        env:
-          MYBRAIN_TOKEN: ${{ secrets.MYBRAIN_TOKEN }}
         run: |
           set -euo pipefail
           mkdir -p ~/.config/opencode/skills ~/.config/opencode/commands

--- a/.github/workflows/P01-general-tech.yml
+++ b/.github/workflows/P01-general-tech.yml
@@ -82,6 +82,7 @@ jobs:
     env:
       GH_REPO: ${{ github.repository }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      MYBRAIN_TOKEN: ${{ secrets.MYBRAIN_TOKEN }}
       OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
       OPENCODE_MODEL: ollama-cloud/${{ vars.OLLAMA_DEFAULT_MODEL || 'deepseek-v4-flash' }}
       OPENCODE_PERMISSION: '{"*":"allow"}'

--- a/.github/workflows/P01-general-tech.yml
+++ b/.github/workflows/P01-general-tech.yml
@@ -183,7 +183,7 @@ jobs:
             attempt=$((attempt+1))
             echo "::group::Step 1 - 執行 opencode (attempt $attempt/$MAX_RETRY)"
             rm -f "${STEP1_LOG}" "${STEP1_REVIEW}"
-            opencode run --model "$OPENCODE_MODEL" --title "step1-$attempt" "$(cat /tmp/step1_prompt.txt)" || echo "opencode run failed (will validate)"
+            GH_TOKEN="$MYBRAIN_TOKEN" opencode run --model "$OPENCODE_MODEL" --title "step1-$attempt" "$(cat /tmp/step1_prompt.txt)" || echo "opencode run failed (will validate)"
             echo "::endgroup::"
 
             echo "::group::Step 1 - Hard validate"
@@ -196,7 +196,7 @@ jobs:
             fi
 
             echo "::group::Step 1 - Soft validate (opencode review)"
-            opencode run --model "$OPENCODE_MODEL" --title "step1-review-$attempt" "$(cat /tmp/step1_review_prompt.txt)" || echo "review run failed"
+            GH_TOKEN="$MYBRAIN_TOKEN" opencode run --model "$OPENCODE_MODEL" --title "step1-review-$attempt" "$(cat /tmp/step1_review_prompt.txt)" || echo "review run failed"
             echo "::endgroup::"
             if ! grep -q "VERDICT: PASS" "${STEP1_REVIEW}" 2>/dev/null; then
               echo "soft validate FAIL, retry"
@@ -257,7 +257,7 @@ jobs:
             attempt=$((attempt+1))
             echo "::group::Step 2 - 執行 opencode (attempt $attempt/$MAX_RETRY)"
             rm -f "${STEP2_LOG}" "${STEP2_REVIEW}"
-            opencode run --model "$OPENCODE_MODEL" --title "step2-$attempt" "$(cat /tmp/step2_prompt.txt)" || echo "opencode run failed (will validate)"
+            GH_TOKEN="$MYBRAIN_TOKEN" opencode run --model "$OPENCODE_MODEL" --title "step2-$attempt" "$(cat /tmp/step2_prompt.txt)" || echo "opencode run failed (will validate)"
             echo "::endgroup::"
 
             echo "::group::Step 2 - Hard validate"
@@ -270,7 +270,7 @@ jobs:
             fi
 
             echo "::group::Step 2 - Soft validate (opencode review)"
-            opencode run --model "$OPENCODE_MODEL" --title "step2-review-$attempt" "$(cat /tmp/step2_review_prompt.txt)" || echo "review run failed"
+            GH_TOKEN="$MYBRAIN_TOKEN" opencode run --model "$OPENCODE_MODEL" --title "step2-review-$attempt" "$(cat /tmp/step2_review_prompt.txt)" || echo "review run failed"
             echo "::endgroup::"
             if ! grep -q "VERDICT: PASS" "${STEP2_REVIEW}" 2>/dev/null; then
               echo "soft validate FAIL, retry"
@@ -360,7 +360,7 @@ jobs:
             if (( current_round_num == 1 )); then
               rm -f output/${PR_NUMBER}_*.md
             fi
-            opencode run --model "$OPENCODE_MODEL" --title "step3-$attempt" "$(cat /tmp/step3_main_prompt.txt)" || echo "opencode run failed (will validate)"
+            GH_TOKEN="$MYBRAIN_TOKEN" opencode run --model "$OPENCODE_MODEL" --title "step3-$attempt" "$(cat /tmp/step3_main_prompt.txt)" || echo "opencode run failed (will validate)"
             echo "::endgroup::"
 
             echo "::group::Step 3 - Hard validate (report)"
@@ -385,7 +385,7 @@ jobs:
             fi
 
             echo "::group::Step 3 - Soft validate (opencode review)"
-            opencode run --model "$OPENCODE_MODEL" --title "step3-review-$attempt" "$(cat /tmp/step3_review_prompt.txt)" || echo "review run failed"
+            GH_TOKEN="$MYBRAIN_TOKEN" opencode run --model "$OPENCODE_MODEL" --title "step3-review-$attempt" "$(cat /tmp/step3_review_prompt.txt)" || echo "review run failed"
             echo "::endgroup::"
             if ! grep -q "VERDICT: PASS" "${STEP3_REVIEW}" 2>/dev/null; then
               echo "soft validate FAIL, retry"
@@ -453,7 +453,7 @@ jobs:
             attempt=$((attempt+1))
             echo "::group::Step 4 - 執行 opencode (attempt $attempt/$MAX_RETRY)"
             rm -f "${STEP4_LOG}" "${STEP4_REVIEW}"
-            opencode run --model "$OPENCODE_MODEL" --title "step4-$attempt" "$(cat /tmp/step4_prompt.txt)" || echo "opencode run failed (will validate)"
+            GH_TOKEN="$MYBRAIN_TOKEN" opencode run --model "$OPENCODE_MODEL" --title "step4-$attempt" "$(cat /tmp/step4_prompt.txt)" || echo "opencode run failed (will validate)"
             echo "::endgroup::"
 
             echo "::group::Step 4 - Hard validate"
@@ -466,7 +466,7 @@ jobs:
             fi
 
             echo "::group::Step 4 - Soft validate (opencode review)"
-            opencode run --model "$OPENCODE_MODEL" --title "step4-review-$attempt" "$(cat /tmp/step4_review_prompt.txt)" || echo "review run failed"
+            GH_TOKEN="$MYBRAIN_TOKEN" opencode run --model "$OPENCODE_MODEL" --title "step4-review-$attempt" "$(cat /tmp/step4_review_prompt.txt)" || echo "review run failed"
             echo "::endgroup::"
             if ! grep -q "VERDICT: PASS" "${STEP4_REVIEW}" 2>/dev/null; then
               echo "soft validate FAIL, retry"

--- a/.github/workflows/P02-code-quality-check.yml
+++ b/.github/workflows/P02-code-quality-check.yml
@@ -104,8 +104,6 @@ jobs:
 
       - name: Setup MyBrain search
         working-directory: .
-        env:
-          MYBRAIN_TOKEN: ${{ secrets.MYBRAIN_TOKEN }}
         run: |
           set -euo pipefail
           mkdir -p ~/.config/opencode/skills ~/.config/opencode/commands

--- a/.github/workflows/P02-code-quality-check.yml
+++ b/.github/workflows/P02-code-quality-check.yml
@@ -175,7 +175,7 @@ jobs:
             attempt=$((attempt+1))
             echo "::group::Step 1 - 執行 opencode (attempt $attempt/$MAX_RETRY)"
             rm -f "${STEP1_LOG}" "${STEP1_REVIEW}"
-            opencode run --model "$OPENCODE_MODEL" --title "step1-$attempt" "$(cat /tmp/step1_prompt.txt)" || echo "opencode run failed (will validate)"
+            GH_TOKEN="$MYBRAIN_TOKEN" opencode run --model "$OPENCODE_MODEL" --title "step1-$attempt" "$(cat /tmp/step1_prompt.txt)" || echo "opencode run failed (will validate)"
             echo "::endgroup::"
 
             echo "::group::Step 1 - Hard validate"
@@ -188,7 +188,7 @@ jobs:
             fi
 
             echo "::group::Step 1 - Soft validate (opencode review)"
-            opencode run --model "$OPENCODE_MODEL" --title "step1-review-$attempt" "$(cat /tmp/step1_review_prompt.txt)" || echo "review run failed"
+            GH_TOKEN="$MYBRAIN_TOKEN" opencode run --model "$OPENCODE_MODEL" --title "step1-review-$attempt" "$(cat /tmp/step1_review_prompt.txt)" || echo "review run failed"
             echo "::endgroup::"
             if ! grep -q "VERDICT: PASS" "${STEP1_REVIEW}" 2>/dev/null; then
               echo "soft validate FAIL, retry"
@@ -251,7 +251,7 @@ jobs:
             attempt=$((attempt+1))
             echo "::group::Step 2 - 執行 opencode (attempt $attempt/$MAX_RETRY)"
             rm -f "${STEP2_LOG}" "${STEP2_REVIEW}"
-            opencode run --model "$OPENCODE_MODEL" --title "step2-$attempt" "$(cat /tmp/step2_prompt.txt)" || echo "opencode run failed (will validate)"
+            GH_TOKEN="$MYBRAIN_TOKEN" opencode run --model "$OPENCODE_MODEL" --title "step2-$attempt" "$(cat /tmp/step2_prompt.txt)" || echo "opencode run failed (will validate)"
             echo "::endgroup::"
 
             echo "::group::Step 2 - Hard validate"
@@ -264,7 +264,7 @@ jobs:
             fi
 
             echo "::group::Step 2 - Soft validate (opencode review)"
-            opencode run --model "$OPENCODE_MODEL" --title "step2-review-$attempt" "$(cat /tmp/step2_review_prompt.txt)" || echo "review run failed"
+            GH_TOKEN="$MYBRAIN_TOKEN" opencode run --model "$OPENCODE_MODEL" --title "step2-review-$attempt" "$(cat /tmp/step2_review_prompt.txt)" || echo "review run failed"
             echo "::endgroup::"
             if ! grep -q "VERDICT: PASS" "${STEP2_REVIEW}" 2>/dev/null; then
               echo "soft validate FAIL, retry"
@@ -348,7 +348,7 @@ jobs:
             if (( current_round_num == 1 )); then
               rm -f output/${PR_NUMBER}_*.md
             fi
-            opencode run --model "$OPENCODE_MODEL" --title "step3-$attempt" "$(cat /tmp/step3_main_prompt.txt)" || echo "opencode run failed (will validate)"
+            GH_TOKEN="$MYBRAIN_TOKEN" opencode run --model "$OPENCODE_MODEL" --title "step3-$attempt" "$(cat /tmp/step3_main_prompt.txt)" || echo "opencode run failed (will validate)"
             echo "::endgroup::"
 
             echo "::group::Step 3 - Hard validate (report)"
@@ -373,7 +373,7 @@ jobs:
             fi
 
             echo "::group::Step 3 - Soft validate (opencode review)"
-            opencode run --model "$OPENCODE_MODEL" --title "step3-review-$attempt" "$(cat /tmp/step3_review_prompt.txt)" || echo "review run failed"
+            GH_TOKEN="$MYBRAIN_TOKEN" opencode run --model "$OPENCODE_MODEL" --title "step3-review-$attempt" "$(cat /tmp/step3_review_prompt.txt)" || echo "review run failed"
             echo "::endgroup::"
             if ! grep -q "VERDICT: PASS" "${STEP3_REVIEW}" 2>/dev/null; then
               echo "soft validate FAIL, retry"
@@ -441,7 +441,7 @@ jobs:
             attempt=$((attempt+1))
             echo "::group::Step 4 - 執行 opencode (attempt $attempt/$MAX_RETRY)"
             rm -f "${STEP4_LOG}" "${STEP4_REVIEW}"
-            opencode run --model "$OPENCODE_MODEL" --title "step4-$attempt" "$(cat /tmp/step4_prompt.txt)" || echo "opencode run failed (will validate)"
+            GH_TOKEN="$MYBRAIN_TOKEN" opencode run --model "$OPENCODE_MODEL" --title "step4-$attempt" "$(cat /tmp/step4_prompt.txt)" || echo "opencode run failed (will validate)"
             echo "::endgroup::"
 
             echo "::group::Step 4 - Hard validate"
@@ -454,7 +454,7 @@ jobs:
             fi
 
             echo "::group::Step 4 - Soft validate (opencode review)"
-            opencode run --model "$OPENCODE_MODEL" --title "step4-review-$attempt" "$(cat /tmp/step4_review_prompt.txt)" || echo "review run failed"
+            GH_TOKEN="$MYBRAIN_TOKEN" opencode run --model "$OPENCODE_MODEL" --title "step4-review-$attempt" "$(cat /tmp/step4_review_prompt.txt)" || echo "review run failed"
             echo "::endgroup::"
             if ! grep -q "VERDICT: PASS" "${STEP4_REVIEW}" 2>/dev/null; then
               echo "soft validate FAIL, retry"

--- a/.github/workflows/P02-code-quality-check.yml
+++ b/.github/workflows/P02-code-quality-check.yml
@@ -78,6 +78,7 @@ jobs:
     env:
       GH_REPO: ${{ github.repository }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      MYBRAIN_TOKEN: ${{ secrets.MYBRAIN_TOKEN }}
       OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
       OPENCODE_MODEL: ollama-cloud/${{ vars.OLLAMA_DEFAULT_MODEL || 'deepseek-v4-flash' }}
       OPENCODE_PERMISSION: '{"*":"allow"}'


### PR DESCRIPTION
Setup step 的 env 只在該 step 有效，opencode 執行 /search-from-mybrain 時拿不到 MYBRAIN_TOKEN，導致 refresh.sh fetch 失敗（雖有舊副本可用但會印警告）。加入 job-level env 解決。