### PR TITLE
fix: PCM 移除 Commit & push step（不再污染 main）

### DIFF
--- a/.github/workflows/PCM-sync-to-mybrain.yml
+++ b/.github/workflows/PCM-sync-to-mybrain.yml
@@ -275,20 +275,6 @@ jobs:
           echo "Sync failed after $MAX_RETRY attempts"
           exit 1
 
-      - name: Commit & push
-        if: always()
-        working-directory: .
-        run: |
-          # 這一步是 always()：前面任何一步炸掉都會走到這，所以 ROUND_ID 可能
-          # 還沒被設起來。-u 遇到未設變數會直接中止，一律給預設值。
-          set -uo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add "${PROJECT_DIR}/memory"
-          git commit -m "sync-to-mybrain: PR #${PR_NUMBER} ${ROUND_ID:-R?}" || echo "nothing to commit"
-          git pull --rebase origin "$(git rev-parse --abbrev-ref HEAD)" || echo "pull rebase skipped"
-          git push --force-with-lease || echo "push failed"
-
       - name: Post result to PR chat
         if: always()
         run: |

--- a/.github/workflows/W00-watch.yml
+++ b/.github/workflows/W00-watch.yml
@@ -176,7 +176,9 @@ jobs:
             soft=$(detect_sync_intent "$last_body")
             if [[ "$soft" == "SYNC" ]]; then
               echo "PR #$pr_number: soft intent=SYNC, posting format hint"
-              gh pr comment "$pr_number" --body "<!-- chatlog:sync-hint -->偵測到你想把這輪的成果存進第二大腦。請用正確格式回文觸發同步：\`/sync-to-mybrain\`（可帶參數指定存什麼，例如 \`/sync-to-mybrain 存進技術評估，判定寫...\`）。" \
+              # 用 GITHUB_TOKEN 以 bot 身分回文——job 的 GH_TOKEN 是 PAT，
+              # 用它會以使用者名義留言，chatlog 解析時會把 hint 當成人類留言。
+              GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}" gh pr comment "$pr_number" --body "<!-- chatlog:sync-hint -->偵測到你想把這輪的成果存進第二大腦。請用正確格式回文觸發同步：\`/sync-to-mybrain\`（可帶參數指定存什麼，例如 \`/sync-to-mybrain 存進技術評估，判定寫...\`）。" \
                 || echo "Failed to post sync hint for PR #$pr_number"
               continue
             fi


### PR DESCRIPTION
PCM 不 checkout PR branch 後，Commit & push 直接在 main 上跑，把 memory/log 推到 main（測試產生了 6930eeb、7ec30e7 兩個殘渣 commit）。sync log 已透過 chatlog 標記貼回 PR chat，不需要進任何 branch。