### PR TITLE
feat: 內部預設模型全部換成 deepseek-v4-flash:0731

### DIFF
--- a/.github/workflows/P00-meta-workflow.yml
+++ b/.github/workflows/P00-meta-workflow.yml
@@ -36,7 +36,7 @@ jobs:
           # token check: 輕量 chat call，非 200 = 無用量或 token 無效
           http_code=$(curl -sS -o /dev/null -w "%{http_code}" -X POST https://ollama.com/api/chat \
             -H "Authorization: Bearer ${{ secrets.OLLAMA_API_KEY }}" -H "Content-Type: application/json" \
-            -d '{"model":"deepseek-v4-flash","messages":[{"role":"user","content":"hi"}],"stream":false}' --max-time 30)
+            -d '{"model":"deepseek-v4-flash:0731","messages":[{"role":"user","content":"hi"}],"stream":false}' --max-time 30)
           if [[ "$http_code" != "200" ]]; then
             echo "FAIL: token check (HTTP $http_code)"
             echo "skip=true" >> "$GITHUB_OUTPUT"; exit 0
@@ -71,7 +71,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       MYBRAIN_TOKEN: ${{ secrets.MYBRAIN_TOKEN }}
       OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
-      OPENCODE_MODEL: ollama-cloud/${{ vars.OLLAMA_DEFAULT_MODEL || 'deepseek-v4-flash' }}
+      OPENCODE_MODEL: ollama-cloud/${{ vars.OLLAMA_DEFAULT_MODEL || 'deepseek-v4-flash:0731' }}
       OPENCODE_PERMISSION: '{"*":"allow"}'
       PROJECT_DIR: projects/P00-meta-workflow
       MAX_RETRY: ${{ github.event.inputs.max_retry || '3' }}

--- a/.github/workflows/P01-general-tech.yml
+++ b/.github/workflows/P01-general-tech.yml
@@ -44,7 +44,7 @@ jobs:
           # token check: 輕量 chat call，非 200 = 無用量或 token 無效
           http_code=$(curl -sS -o /dev/null -w "%{http_code}" -X POST https://ollama.com/api/chat \
             -H "Authorization: Bearer ${{ secrets.OLLAMA_API_KEY }}" -H "Content-Type: application/json" \
-            -d '{"model":"deepseek-v4-flash","messages":[{"role":"user","content":"hi"}],"stream":false}' --max-time 30)
+            -d '{"model":"deepseek-v4-flash:0731","messages":[{"role":"user","content":"hi"}],"stream":false}' --max-time 30)
           if [[ "$http_code" != "200" ]]; then
             echo "FAIL: token check (HTTP $http_code)"
             echo "skip=true" >> "$GITHUB_OUTPUT"; exit 0
@@ -84,7 +84,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       MYBRAIN_TOKEN: ${{ secrets.MYBRAIN_TOKEN }}
       OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
-      OPENCODE_MODEL: ollama-cloud/${{ vars.OLLAMA_DEFAULT_MODEL || 'deepseek-v4-flash' }}
+      OPENCODE_MODEL: ollama-cloud/${{ vars.OLLAMA_DEFAULT_MODEL || 'deepseek-v4-flash:0731' }}
       OPENCODE_PERMISSION: '{"*":"allow"}'
       PROJECT_DIR: projects/P01-general-tech
       MAX_RETRY: ${{ github.event.inputs.max_retry || '3' }}

--- a/.github/workflows/P02-code-quality-check.yml
+++ b/.github/workflows/P02-code-quality-check.yml
@@ -42,7 +42,7 @@ jobs:
 
           http_code=$(curl -sS -o /dev/null -w "%{http_code}" -X POST https://ollama.com/api/chat \
             -H "Authorization: Bearer ${{ secrets.OLLAMA_API_KEY }}" -H "Content-Type: application/json" \
-            -d '{"model":"deepseek-v4-flash","messages":[{"role":"user","content":"hi"}],"stream":false}' --max-time 30)
+            -d '{"model":"deepseek-v4-flash:0731","messages":[{"role":"user","content":"hi"}],"stream":false}' --max-time 30)
           if [[ "$http_code" != "200" ]]; then
             echo "FAIL: token check (HTTP $http_code)"
             echo "skip=true" >> "$GITHUB_OUTPUT"; exit 0
@@ -80,7 +80,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       MYBRAIN_TOKEN: ${{ secrets.MYBRAIN_TOKEN }}
       OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
-      OPENCODE_MODEL: ollama-cloud/${{ vars.OLLAMA_DEFAULT_MODEL || 'deepseek-v4-flash' }}
+      OPENCODE_MODEL: ollama-cloud/${{ vars.OLLAMA_DEFAULT_MODEL || 'deepseek-v4-flash:0731' }}
       OPENCODE_PERMISSION: '{"*":"allow"}'
       PROJECT_DIR: projects/P02-code-quality-check
       MAX_RETRY: ${{ github.event.inputs.max_retry || '3' }}

--- a/.github/workflows/PCM-sync-to-mybrain.yml
+++ b/.github/workflows/PCM-sync-to-mybrain.yml
@@ -49,7 +49,7 @@ jobs:
           # token check: 輕量 chat call，非 200 = 無用量或 token 無效
           http_code=$(curl -sS -o /dev/null -w "%{http_code}" -X POST https://ollama.com/api/chat \
             -H "Authorization: Bearer ${{ secrets.OLLAMA_API_KEY }}" -H "Content-Type: application/json" \
-            -d '{"model":"deepseek-v4-flash","messages":[{"role":"user","content":"hi"}],"stream":false}' --max-time 30)
+            -d '{"model":"deepseek-v4-flash:0731","messages":[{"role":"user","content":"hi"}],"stream":false}' --max-time 30)
           if [[ "$http_code" != "200" ]]; then
             echo "FAIL: token check (HTTP $http_code)"
             echo "skip=true" >> "$GITHUB_OUTPUT"; exit 0
@@ -78,7 +78,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       MYBRAIN_TOKEN: ${{ secrets.MYBRAIN_TOKEN }}
       OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
-      OPENCODE_MODEL: ollama-cloud/${{ vars.OLLAMA_DEFAULT_MODEL || 'deepseek-v4-flash' }}
+      OPENCODE_MODEL: ollama-cloud/${{ vars.OLLAMA_DEFAULT_MODEL || 'deepseek-v4-flash:0731' }}
       OPENCODE_PERMISSION: '{"*":"allow"}'
       PROJECT_DIR: projects/PCM-sync-to-mybrain
       SOURCE_PROJECT: ${{ needs.guard.outputs.source_project }}

--- a/.github/workflows/T00-verify-ollama-cloud.yml
+++ b/.github/workflows/T00-verify-ollama-cloud.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       model:
-        description: "Ollama Cloud model id (e.g. deepseek-v4-flash)"
+        description: "Ollama Cloud model id (e.g. deepseek-v4-flash:0731)"
         required: false
-        default: "deepseek-v4-flash"
+        default: "deepseek-v4-flash:0731"
       prompt:
         description: "Prompt to send to the model"
         required: false

--- a/.github/workflows/W00-watch.yml
+++ b/.github/workflows/W00-watch.yml
@@ -23,7 +23,7 @@ jobs:
       GH_TOKEN: ${{ secrets.LEARNGHAGENT_TOKEN }}
       # 軟判定（sync 意圖分類）用。判斷「這則留言有沒有 sync-to-mybrain 意圖」。
       OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
-      CLASSIFIER_MODEL: ${{ vars.OLLAMA_DEFAULT_MODEL || 'deepseek-v4-flash' }}
+      CLASSIFIER_MODEL: ${{ vars.OLLAMA_DEFAULT_MODEL || 'deepseek-v4-flash:0731' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/projects/P00-meta-workflow/opencode.json
+++ b/projects/P00-meta-workflow/opencode.json
@@ -10,14 +10,23 @@
         "setCacheKey": true
       },
       "models": {
-        "deepseek-v4-pro": { "name": "DeepSeek V4 Pro" },
-        "deepseek-v4-flash": { "name": "DeepSeek V4 Flash" },
-        "glm-5.2": { "name": "GLM 5.2" }
+        "deepseek-v4-pro": {
+          "name": "DeepSeek V4 Pro"
+        },
+        "deepseek-v4-flash": {
+          "name": "DeepSeek V4 Flash"
+        },
+        "glm-5.2": {
+          "name": "GLM 5.2"
+        },
+        "deepseek-v4-flash:0731": {
+          "name": "DeepSeek V4 Flash 0731"
+        }
       }
     }
   },
-  "model": "ollama-cloud/deepseek-v4-pro",
-  "small_model": "ollama-cloud/deepseek-v4-pro",
+  "model": "ollama-cloud/deepseek-v4-flash:0731",
+  "small_model": "ollama-cloud/deepseek-v4-flash:0731",
   "instructions": [
     "know/AGENTS.md",
     "know/我.md"

--- a/projects/P01-general-tech/opencode.json
+++ b/projects/P01-general-tech/opencode.json
@@ -10,14 +10,23 @@
         "setCacheKey": true
       },
       "models": {
-        "deepseek-v4-pro": { "name": "DeepSeek V4 Pro" },
-        "deepseek-v4-flash": { "name": "DeepSeek V4 Flash" },
-        "glm-5.2": { "name": "GLM 5.2" }
+        "deepseek-v4-pro": {
+          "name": "DeepSeek V4 Pro"
+        },
+        "deepseek-v4-flash": {
+          "name": "DeepSeek V4 Flash"
+        },
+        "glm-5.2": {
+          "name": "GLM 5.2"
+        },
+        "deepseek-v4-flash:0731": {
+          "name": "DeepSeek V4 Flash 0731"
+        }
       }
     }
   },
-  "model": "ollama-cloud/deepseek-v4-pro",
-  "small_model": "ollama-cloud/deepseek-v4-pro",
+  "model": "ollama-cloud/deepseek-v4-flash:0731",
+  "small_model": "ollama-cloud/deepseek-v4-flash:0731",
   "instructions": [
     "know/AGENTS.md",
     "know/我.md"

--- a/projects/P02-code-quality-check/opencode.json
+++ b/projects/P02-code-quality-check/opencode.json
@@ -10,14 +10,23 @@
         "setCacheKey": true
       },
       "models": {
-        "deepseek-v4-pro": { "name": "DeepSeek V4 Pro" },
-        "deepseek-v4-flash": { "name": "DeepSeek V4 Flash" },
-        "glm-5.2": { "name": "GLM 5.2" }
+        "deepseek-v4-pro": {
+          "name": "DeepSeek V4 Pro"
+        },
+        "deepseek-v4-flash": {
+          "name": "DeepSeek V4 Flash"
+        },
+        "glm-5.2": {
+          "name": "GLM 5.2"
+        },
+        "deepseek-v4-flash:0731": {
+          "name": "DeepSeek V4 Flash 0731"
+        }
       }
     }
   },
-  "model": "ollama-cloud/deepseek-v4-pro",
-  "small_model": "ollama-cloud/deepseek-v4-pro",
+  "model": "ollama-cloud/deepseek-v4-flash:0731",
+  "small_model": "ollama-cloud/deepseek-v4-flash:0731",
   "instructions": [
     "know/AGENTS.md",
     "know/我.md"

--- a/projects/PCM-sync-to-mybrain/opencode.json
+++ b/projects/PCM-sync-to-mybrain/opencode.json
@@ -10,14 +10,23 @@
         "setCacheKey": true
       },
       "models": {
-        "deepseek-v4-pro": { "name": "DeepSeek V4 Pro" },
-        "deepseek-v4-flash": { "name": "DeepSeek V4 Flash" },
-        "glm-5.2": { "name": "GLM 5.2" }
+        "deepseek-v4-pro": {
+          "name": "DeepSeek V4 Pro"
+        },
+        "deepseek-v4-flash": {
+          "name": "DeepSeek V4 Flash"
+        },
+        "glm-5.2": {
+          "name": "GLM 5.2"
+        },
+        "deepseek-v4-flash:0731": {
+          "name": "DeepSeek V4 Flash 0731"
+        }
       }
     }
   },
-  "model": "ollama-cloud/deepseek-v4-pro",
-  "small_model": "ollama-cloud/deepseek-v4-pro",
+  "model": "ollama-cloud/deepseek-v4-flash:0731",
+  "small_model": "ollama-cloud/deepseek-v4-flash:0731",
   "instructions": [
     "know/AGENTS.md",
     "know/我.md"


### PR DESCRIPTION
4 個 harness opencode.json + 5 個 workflow 的內部預設模型全部換成 ollama-cloud 的 deepseek-v4-flash:0731：

- opencode.json：model/small_model → ollama-cloud/deepseek-v4-flash:0731
- OPENCODE_MODEL fallback → deepseek-v4-flash:0731
- W00 CLASSIFIER_MODEL fallback → deepseek-v4-flash:0731
- guard token check curl model → deepseek-v4-flash:0731
- T00 verify default → deepseek-v4-flash:0731

已實測 0731 在 ollama-cloud 可用。