### PR TITLE
fix(sync): hard validate 掐死 retry ＋ refresh.sh 在 CI 拿不到認證

### DIFF
--- a/.github/workflows/P00-meta-workflow.yml
+++ b/.github/workflows/P00-meta-workflow.yml
@@ -102,6 +102,10 @@ jobs:
           # 這裡不必再改。skill 是本體，command 只是薄殼入口。
           cp -r .agents/skills/. ~/.config/opencode/skills/
           cp .agents/commands/*.md ~/.config/opencode/commands/
+          # refresh.sh 的 git fetch 要 gh 認證（private repo）。job 的 GH_TOKEN
+          # 是 GITHUB_TOKEN，對 MyBrain 無權限——設好 credential helper 讓
+          # fetch 走 MYBRAIN_TOKEN，否則每次 CI 都抓到失敗、沿用舊鏡像。
+          GH_TOKEN="$MYBRAIN_TOKEN" gh auth setup-git || echo "gh auth setup-git failed (refresh 可能失敗)"
           GH_TOKEN="$MYBRAIN_TOKEN" MYBRAIN_DIR=/tmp/mybrain bash .agents/skills/mybrain-read/refresh.sh || true
           echo "MyBrain @ $(git -C /tmp/mybrain log -1 --format='%h %ad' --date=short 2>/dev/null || echo 'unavailable')"
 

--- a/.github/workflows/P01-general-tech.yml
+++ b/.github/workflows/P01-general-tech.yml
@@ -115,6 +115,10 @@ jobs:
           # 這裡不必再改。skill 是本體，command 只是薄殼入口。
           cp -r .agents/skills/. ~/.config/opencode/skills/
           cp .agents/commands/*.md ~/.config/opencode/commands/
+          # refresh.sh 的 git fetch 要 gh 認證（private repo）。job 的 GH_TOKEN
+          # 是 GITHUB_TOKEN，對 MyBrain 無權限——設好 credential helper 讓
+          # fetch 走 MYBRAIN_TOKEN，否則每次 CI 都抓到失敗、沿用舊鏡像。
+          GH_TOKEN="$MYBRAIN_TOKEN" gh auth setup-git || echo "gh auth setup-git failed (refresh 可能失敗)"
           GH_TOKEN="$MYBRAIN_TOKEN" MYBRAIN_DIR=/tmp/mybrain bash .agents/skills/mybrain-read/refresh.sh || true
           echo "MyBrain @ $(git -C /tmp/mybrain log -1 --format='%h %ad' --date=short 2>/dev/null || echo 'unavailable')"
 

--- a/.github/workflows/P02-code-quality-check.yml
+++ b/.github/workflows/P02-code-quality-check.yml
@@ -111,6 +111,10 @@ jobs:
           # 這裡不必再改。skill 是本體，command 只是薄殼入口。
           cp -r .agents/skills/. ~/.config/opencode/skills/
           cp .agents/commands/*.md ~/.config/opencode/commands/
+          # refresh.sh 的 git fetch 要 gh 認證（private repo）。job 的 GH_TOKEN
+          # 是 GITHUB_TOKEN，對 MyBrain 無權限——設好 credential helper 讓
+          # fetch 走 MYBRAIN_TOKEN，否則每次 CI 都抓到失敗、沿用舊鏡像。
+          GH_TOKEN="$MYBRAIN_TOKEN" gh auth setup-git || echo "gh auth setup-git failed (refresh 可能失敗)"
           GH_TOKEN="$MYBRAIN_TOKEN" MYBRAIN_DIR=/tmp/mybrain bash .agents/skills/mybrain-read/refresh.sh || true
           echo "MyBrain @ $(git -C /tmp/mybrain log -1 --format='%h %ad' --date=short 2>/dev/null || echo 'unavailable')"
 

--- a/.github/workflows/PCM-sync-to-mybrain.yml
+++ b/.github/workflows/PCM-sync-to-mybrain.yml
@@ -253,8 +253,11 @@ jobs:
             echo "::endgroup::"
 
             echo "::group::Sync - Hard validate"
-            GH_TOKEN="$MYBRAIN_TOKEN" judge/validate-step-sync.sh "${SYNC_LOG}"
-            hard_rc=$?
+            if GH_TOKEN="$MYBRAIN_TOKEN" judge/validate-step-sync.sh "${SYNC_LOG}"; then
+              hard_rc=0
+            else
+              hard_rc=$?
+            fi
             echo "::endgroup::"
             if [[ $hard_rc -ne 0 ]]; then
               echo "hard validate failed, retry"

--- a/projects/PCM-sync-to-mybrain/judge/validate-step-sync.sh
+++ b/projects/PCM-sync-to-mybrain/judge/validate-step-sync.sh
@@ -19,15 +19,18 @@ for sec in "## 狀況理解" "## 執行的動作與結果" "## 動作結束後�
 done
 
 # 最後一行（忽略尾端空行）必須是 MYBRAIN_PR 標記。
+# 模型常把這行包成 markdown code（`MYBRAIN_PR: <url>`）——剝掉行首結尾的
+# ` 與 * 再比對，形狀對了就算數。真正的防偽靠下面的 gh 實查，不靠字串形狀。
 last_line="$(grep -v '^[[:space:]]*$' "$file" | tail -1)"
-if [[ "$last_line" =~ ^MYBRAIN_PR:\ https://github\.com/FATESAIKOU/MyBrain/pull/([0-9]+)$ ]]; then
+normalized="$(printf '%s' "$last_line" | sed -E 's/^[`*]+//; s/[`*]+$//')"
+if [[ "$normalized" =~ ^MYBRAIN_PR:\ https://github\.com/FATESAIKOU/MyBrain/pull/([0-9]+)$ ]]; then
   pr_number="${BASH_REMATCH[1]}"
   if ! gh pr view -R FATESAIKOU/MyBrain "$pr_number" --json number -q .number >/dev/null 2>&1; then
     echo "FAIL: $file 標記的 MyBrain PR #$pr_number 不存在" >&2
     exit 1
   fi
   echo "OK: sync log valid (PR #$pr_number exists)"
-elif [[ "$last_line" =~ ^MYBRAIN_PR:\ SKIPPED\ -\ .+$ ]]; then
+elif [[ "$normalized" =~ ^MYBRAIN_PR:\ SKIPPED\ -\ .+$ ]]; then
   echo "OK: sync log valid (skipped, reason recorded)"
 else
   echo "FAIL: $file 最後一行必須是 'MYBRAIN_PR: <PR 網址>' 或 'MYBRAIN_PR: SKIPPED - <原因>'" >&2


### PR DESCRIPTION
## 問題

兩個 bug 都在本次端到端實測（PR #200 → sync）中實證：

**Bug 1 — PCM hard validate 失敗會掐死 retry**
- 實測：模型把 SYNC_LOG 最後一行寫成 `MYBRAIN_PR: <url>`（markdown backtick），validate regex 精確匹配失敗 → 但 GitHub Actions 的 run step 隱含 -e，腳本當場退出，hard_rc=$? 與 retry loop 永遠不會執行 → **PR 已開成功、job 卻標紅**，第一次 attempt 就死
- 治本：validate 改放進 if 條件語境（豁免 -e），retry 恢復作用；第二次 attempt 會偵測既有 PR、以 printf 寫出乾淨格式直接 PASS
- 治標：regex 剝掉行首結尾的 ` 與 \* 再比對。防偽仍靠 gh 實查 PR 是否存在，不靠字串形狀

**Bug 2 — P0x workflow 的 refresh.sh 在 CI 必失敗（靜默沿用舊鏡像）**
- refresh.sh 的 git fetch 需要 gh 認證；job 的 GH_TOKEN 是 GITHUB_TOKEN，對 private 的 MyBrain 無權限
- 補 `gh auth setup-git`（與 PCM 一致），讓 fetch 走 MYBRAIN_TOKEN

## 驗證

- validate regex：三案例實測（backtick URL → PASS、星號 SKIPPED → PASS、假 PR 編號 → FAIL 被 gh 實查擋下）
- 5 支 workflow YAML 全部 parse OK
- retry 修法內嵌 shell bash -n 通過

## Review 重點

- PCM execute step 的 if/else 寫法（治本）是否可接受
- regex 放寬後，gh 實查那條仍在，防偽沒變弱